### PR TITLE
Fix spacing between phone number and scroll indicator

### DIFF
--- a/src/app/components/header/header.component.scss
+++ b/src/app/components/header/header.component.scss
@@ -113,7 +113,7 @@ header.header {
         justify-content: center;
         position: relative;
         z-index: 1;
-        padding: 40px 0 100px;
+        padding: 40px 0 140px;
     }
 
     .hero-content {


### PR DESCRIPTION
## Fix: Scroll Indicator Spacing

Increased the hero section's bottom padding from 100px to 140px to provide adequate visual separation between the contact pills (phone number) and the scroll animation indicator.

The scroll indicator is absolutely positioned at `bottom: 30px` and is ~60px tall, which previously left only ~10px of gap with the contact pills. The extra 40px of padding gives comfortable breathing room.

_This PR was generated with [Oz](https://www.warp.dev/oz)._
